### PR TITLE
Port PRs to solve data corruption in HTTP/2

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -395,6 +395,10 @@ static ssize_t send_callback(nghttp2_session *h2,
   written = ((Curl_send*)c->send_underlying)(data, FIRSTSOCKET,
                                              mem, length, &result);
 
+  if (written >= 0 && (size_t) written < length) {
+    H2BUGF(infof(data, "[SUPER-6847] we don't have implementation to handle this case"));
+  }
+
   if(result == CURLE_AGAIN) {
     return NGHTTP2_ERR_WOULDBLOCK;
   }


### PR DESCRIPTION
https://github.com/curl/curl/pull/10529
https://github.com/curl/curl/pull/10530

Not completed. I couldn't port this part:

```
  if((size_t)written < buflen) {
    Curl_dyn_tail(&ctx->outbuf, buflen - (size_t)written);
    return CURLE_AGAIN;
  }
```

because we don't have buffer to store unsent data. But this is for sending data, PUT and POST. I think the relationship with the issue is not huge.